### PR TITLE
:bug: Start informers for objects that they haven't been started for yet

### DIFF
--- a/examples/apiexport/main.go
+++ b/examples/apiexport/main.go
@@ -121,7 +121,7 @@ func main() {
 					return reconcile.Result{}, fmt.Errorf("failed to get configmap: %w", err)
 				}
 
-				log.Info("Reconciling configmap", "name", s.Name, "uuid", s.UID)
+				log.Info("Reconciling ConfigMap", "name", s.Name, "uuid", s.UID)
 
 				return reconcile.Result{}, nil
 			},

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/kcp-dev/apimachinery/v2 v2.0.1-0.20240817110845-a9eb9752bfeb
 	github.com/kcp-dev/kcp/sdk v0.26.1
 	github.com/kcp-dev/logicalcluster/v3 v3.0.5
-	github.com/multicluster-runtime/multicluster-runtime v0.20.0-alpha.3
+	github.com/multicluster-runtime/multicluster-runtime v0.20.0-alpha.5
 	github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/sync v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/multicluster-runtime/multicluster-runtime v0.20.0-alpha.3 h1:GLVW6WCrHbuyrSOcMpXUd/svnW32YLRMJPwRwAiR8zI=
-github.com/multicluster-runtime/multicluster-runtime v0.20.0-alpha.3/go.mod h1:6ZuT8VoTSr8nYyToyhnhAepyZoHAaCQzzabzbSFwAKc=
+github.com/multicluster-runtime/multicluster-runtime v0.20.0-alpha.5 h1:aoDDYIbqFXbRfWVbQEl5l5KktEVWntuwD2gpPMEIr4A=
+github.com/multicluster-runtime/multicluster-runtime v0.20.0-alpha.5/go.mod h1:6ZuT8VoTSr8nYyToyhnhAepyZoHAaCQzzabzbSFwAKc=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/onsi/ginkgo/v2 v2.21.0 h1:7rg/4f3rB88pb5obDgNZrNHrQ4e6WpjonchcpuBRnZM=

--- a/virtualworkspace/cache.go
+++ b/virtualworkspace/cache.go
@@ -52,12 +52,9 @@ func (c *scopedCache) IndexField(ctx context.Context, obj client.Object, field s
 
 // Get returns a single object from the cache.
 func (c *scopedCache) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-	inf, gvk, scope, found, err := c.base.getSharedInformer(obj)
+	inf, gvk, scope, err := c.base.getSharedInformer(obj)
 	if err != nil {
 		return fmt.Errorf("failed to get informer for %T %s: %w", obj, obj.GetObjectKind().GroupVersionKind(), err)
-	}
-	if !found {
-		return fmt.Errorf("no informer found for %T %s", obj, obj.GetObjectKind().GroupVersionKind())
 	}
 
 	cr := cacheReader{
@@ -73,12 +70,9 @@ func (c *scopedCache) Get(ctx context.Context, key client.ObjectKey, obj client.
 
 // List returns a list of objects from the cache.
 func (c *scopedCache) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
-	inf, gvk, scope, found, err := c.base.getSharedInformer(list)
+	inf, gvk, scope, err := c.base.getSharedInformer(list)
 	if err != nil {
 		return fmt.Errorf("failed to get informer for %T %s: %w", list, list.GetObjectKind().GroupVersionKind(), err)
-	}
-	if !found {
-		return fmt.Errorf("no informer found for %T %s", list, list.GetObjectKind().GroupVersionKind())
 	}
 
 	cr := cacheReader{

--- a/virtualworkspace/provider.go
+++ b/virtualworkspace/provider.go
@@ -227,3 +227,8 @@ func (p *Provider) Get(_ context.Context, name string) (cluster.Cluster, error) 
 func (p *Provider) GetWildcard() cache.Cache {
 	return p.cache
 }
+
+// IndexField indexes the given object by the given field on all engaged clusters, current and future.
+func (p *Provider) IndexField(ctx context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error {
+	return p.cache.IndexField(ctx, obj, field, extractValue)
+}

--- a/virtualworkspace/provider.go
+++ b/virtualworkspace/provider.go
@@ -109,7 +109,7 @@ func (p *Provider) Run(ctx context.Context, mgr mcmanager.Manager) error {
 	if err != nil {
 		return fmt.Errorf("failed to get logical cluster informer: %w", err)
 	}
-	shInf, _, _, _, err := p.cache.getSharedInformer(p.object)
+	shInf, _, _, err := p.cache.getSharedInformer(p.object)
 	if err != nil {
 		return fmt.Errorf("failed to get shared informer: %w", err)
 	}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

As per the example in #7, we were unable to `List` or `Get` objects that are not watched by the controller. This change attempts to emulate what upstream controller-runtime's cache implementation does: When an informer has not been started yet, we should try to start one.

The way we start a new informer is a bit hacky due to our custom `NewInformer` logic, but this should do the trick.

## Related issue(s)

Fixes #8

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
