### PR TITLE
Pass configured provider schema to scoped cluster clients

### DIFF
--- a/virtualworkspace/cluster.go
+++ b/virtualworkspace/cluster.go
@@ -49,7 +49,7 @@ func newScopedCluster(cfg *rest.Config, clusterName logicalcluster.Name, wildcar
 		clusterName: clusterName,
 	}
 
-	cli, err := client.New(cfg, client.Options{Cache: &client.CacheOptions{Reader: ca}})
+	cli, err := client.New(cfg, client.Options{Cache: &client.CacheOptions{Reader: ca}, Scheme: scheme})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

The schema configured while initializing the provider, via `virtualworkspace.Options`, is not passed to the clients of scoped cluster resulting them to use default schema and not recognizing the types configured in the original schema.

This is a tiny PR passing configured provider schema to scoped cluster clients.

## What Type of PR Is This?
/kind bug

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Fixed passing configuring provider schema to scoped cluster clients.
```
