### PR TITLE
Upgrade to multicluster-runtime v0.20.4-alpha.7

### DIFF
--- a/apiexport/provider.go
+++ b/apiexport/provider.go
@@ -225,7 +225,7 @@ func (p *Provider) Get(_ context.Context, name string) (cluster.Cluster, error) 
 		return cl, nil
 	}
 
-	return nil, fmt.Errorf("cluster %q not found", name)
+	return nil, multicluster.ErrClusterNotFound
 }
 
 // GetWildcard returns the wildcard cache.

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
 	sigs.k8s.io/controller-runtime v0.20.4
-	sigs.k8s.io/multicluster-runtime v0.20.4-alpha.6
+	sigs.k8s.io/multicluster-runtime v0.20.4-alpha.7
 	sigs.k8s.io/yaml v1.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -226,8 +226,8 @@ sigs.k8s.io/controller-runtime v0.20.4 h1:X3c+Odnxz+iPTRobG4tp092+CvBU9UK0t/bRf+
 sigs.k8s.io/controller-runtime v0.20.4/go.mod h1:xg2XB0K5ShQzAgsoujxuKN4LNXR2LfwwHsPj7Iaw+XY=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 h1:/Rv+M11QRah1itp8VhT6HoVx1Ray9eB4DBr+K+/sCJ8=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3/go.mod h1:18nIHnGi6636UCz6m8i4DhaJ65T6EruyzmoQqI2BVDo=
-sigs.k8s.io/multicluster-runtime v0.20.4-alpha.6 h1:xaBJoiYZY+DlaHBIXfS+ZUH+L5GOD6A+klL46vekggE=
-sigs.k8s.io/multicluster-runtime v0.20.4-alpha.6/go.mod h1:2N2/c3p08bYC9eDaRs0dllTxgAm5xiLDSkmGZpWKyw4=
+sigs.k8s.io/multicluster-runtime v0.20.4-alpha.7 h1:AFlM/TFQaESxtCRX6scodEKensLhcbfGwXfjJIvoaT8=
+sigs.k8s.io/multicluster-runtime v0.20.4-alpha.7/go.mod h1:2N2/c3p08bYC9eDaRs0dllTxgAm5xiLDSkmGZpWKyw4=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.2 h1:MdmvkGuXi/8io6ixD5wud3vOLwc1rj0aNqRlpuvjmwA=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.2/go.mod h1:N8f93tFZh9U6vpxwRArLiikrE5/2tiu1w1AGfACIGE4=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Small PR to upgrade to `sigs.k8s.io/multicluster-runtime` and implement the new `ErrClusterNotFound` error returned by providers.

## What Type of PR Is This?

/kind feature

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Upgrade to sigs.k8s.io/multicluster-runtime v0.20.4-alpha.7
```
