### PR TITLE
apiexport: make object to watch optional, default to `APIBindings`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ $(YQ):
 	  yq_*
 
 KCP = _tools/kcp
-KCP_VERSION = 0.26.1
+KCP_VERSION = 0.27.1
 
 .PHONY: $(KCP)
 $(KCP):

--- a/examples/apiexport/main.go
+++ b/examples/apiexport/main.go
@@ -79,17 +79,10 @@ func main() {
 	opts := manager.Options{}
 
 	var err error
-	provider, err = apiexport.New(cfg, &apisv1alpha1.APIBinding{}, apiexport.Options{})
+	provider, err = apiexport.New(cfg, apiexport.Options{})
 	if err != nil {
 		entryLog.Error(err, "unable to construct cluster provider")
 		os.Exit(1)
-	}
-
-	cfg.WrapTransport = func(rt http.RoundTripper) http.RoundTripper {
-		return RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
-			fmt.Println(r.URL)
-			return rt.RoundTrip(r)
-		})
 	}
 
 	mgr, err := mcmanager.New(cfg, provider, opts)

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.23.5
 require (
 	github.com/go-logr/logr v1.4.2
 	github.com/hashicorp/golang-lru/v2 v2.0.7
-	github.com/kcp-dev/apimachinery/v2 v2.0.1-0.20240817110845-a9eb9752bfeb
-	github.com/kcp-dev/kcp/sdk v0.26.1
+	github.com/kcp-dev/apimachinery/v2 v2.0.1-0.20250223115924-431177b024f3
+	github.com/kcp-dev/kcp/sdk v0.27.1
 	github.com/kcp-dev/logicalcluster/v3 v3.0.5
 	github.com/martinlindhe/base36 v1.1.1
 	github.com/onsi/ginkgo/v2 v2.22.0

--- a/go.sum
+++ b/go.sum
@@ -67,10 +67,10 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
-github.com/kcp-dev/apimachinery/v2 v2.0.1-0.20240817110845-a9eb9752bfeb h1:W11F/dp6NdUnHeB0SrpyWLiifRosu1qaMJvdFGGLXc0=
-github.com/kcp-dev/apimachinery/v2 v2.0.1-0.20240817110845-a9eb9752bfeb/go.mod h1:mEDD1K5BVUXJ4CP6wcJ0vZUf+7tbFMjkCFzBKsUNj18=
-github.com/kcp-dev/kcp/sdk v0.26.1 h1:kzowAqlO6gfSmNFOXtcskg0tOhd8etG72XqvW06BUb0=
-github.com/kcp-dev/kcp/sdk v0.26.1/go.mod h1:XjabYVlKkpuRr1qATymS0gMTEjC6McuuwdoVGSar2fE=
+github.com/kcp-dev/apimachinery/v2 v2.0.1-0.20250223115924-431177b024f3 h1:YwNX7ZIpQXg9u5vav/fobmf4nnO0WhbELWaL3X74Oe4=
+github.com/kcp-dev/apimachinery/v2 v2.0.1-0.20250223115924-431177b024f3/go.mod h1:n0+EV+LGKl1MXXqGbGcn0AaBv7hdKsdazSYuq8nM8Us=
+github.com/kcp-dev/kcp/sdk v0.27.1 h1:jBVdrZoJd5hy2RqaBnmCCzldimwOqDkf8FXtNq5HaWA=
+github.com/kcp-dev/kcp/sdk v0.27.1/go.mod h1:3eRgW42d81Ng60DbG1xbne0FSS2znpcN/GUx4rqJgUo=
 github.com/kcp-dev/logicalcluster/v3 v3.0.5 h1:JbYakokb+5Uinz09oTXomSUJVQsqfxEvU4RyHUYxHOU=
 github.com/kcp-dev/logicalcluster/v3 v3.0.5/go.mod h1:EWBUBxdr49fUB1cLMO4nOdBWmYifLbP1LfoL20KkXYY=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/test/e2e/apiexport_test.go
+++ b/test/e2e/apiexport_test.go
@@ -234,7 +234,7 @@ var _ = Describe("VirtualWorkspace Provider", Ordered, func() {
 			vwConfig := rest.CopyConfig(kcpConfig)
 			vwConfig.Host = vwEndpoint
 			var err error
-			p, err = apiexport.New(vwConfig, &apisv1alpha1.APIBinding{}, apiexport.Options{})
+			p, err = apiexport.New(vwConfig, apiexport.Options{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("waiting for discovery of the virtual workspace to show 'example.com'")


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

This PR does two things:

1. It bumps to the latest kcp version (0.27.1) since we were testing against an older version.
2. It removes the `obj client.Object` parameter from `apiexport.New`. This made sense when we considered this to be a generic provider for any virtual workspace, but this will be extremely tricky due to changed semantics across virtual workspaces. Therefore, this PR is making passing an object to watch optional and just gives a configuration option if someone really wants to change it.

This is essentially a continuation of #18 to make it make sense. I remember a discussion in a PR where we were talking about this parameter (optional vs mandatory) and it made sense at the time to make it mandatory, but with the provider being more specialised now I think we should remove this option.

## What Type of PR Is This?

/kind cleanup
/kind api-change

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
* Update to kcp 0.27.1
* Remove `obj` parameter from `apiexport.New` and add `apiexport.Options.ObjectToWatch` instead
```
