### PR TITLE
Use multicluster.Aware in provider.Start function signature

### DIFF
--- a/apiexport/provider.go
+++ b/apiexport/provider.go
@@ -35,7 +35,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
 
 	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
@@ -117,7 +116,7 @@ func New(cfg *rest.Config, options Options) (*Provider, error) {
 }
 
 // Run starts the provider and blocks.
-func (p *Provider) Run(ctx context.Context, mgr mcmanager.Manager) error {
+func (p *Provider) Run(ctx context.Context, aware multicluster.Aware) error {
 	g, ctx := errgroup.WithContext(ctx)
 
 	// Watch logical clusters and engage them as clusters in multicluster-runtime.
@@ -167,7 +166,7 @@ func (p *Provider) Run(ctx context.Context, mgr mcmanager.Manager) error {
 			p.lock.Unlock()
 
 			p.log.Info("engaging cluster", "cluster", clusterName)
-			if err := mgr.Engage(clusterCtx, clusterName.String(), cl); err != nil {
+			if err := aware.Engage(clusterCtx, clusterName.String(), cl); err != nil {
 				p.log.Error(err, "failed to engage cluster", "cluster", clusterName)
 				p.lock.Lock()
 				cancel()


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

This is not necessarily something to merge, more of a RFC. I realized we were only using `Engage` in the provider startup, and it seemed to me it would be a nice idea to use `multicluster.Aware` instead of the whole `mcmanager.Manager` kitchen sink. This way, you can use the provider in more custom scenarios (in specific, @xrstf and I are currently re-thinking the api-syncagent to move it to multicluster-runtime, and we might not even use the `mcmanager.Manager` directly).

Any thoughts on this?

## What Type of PR Is This?

/kind cleanup
/kind api-change

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Replace `mcmanager.Manager` with `multicluster.Aware` in `apiexport.(p *Provider).Start` function signature
```
