### PR TITLE
Use Go 1.23.10 for prow jobs

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.23.9-1
+        - image: ghcr.io/kcp-dev/infra/build:1.23.10-1
           command:
             - make
             - verify
@@ -38,7 +38,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.23.9-1
+        - image: ghcr.io/kcp-dev/infra/build:1.23.10-1
           command:
             - make
             - lint
@@ -55,7 +55,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.23.9-1
+        - image: ghcr.io/kcp-dev/infra/build:1.23.10-1
           command:
             - make
             - test


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Tiny Friday afternoon PR to update to Go 1.23.10.

## What Type of PR Is This?

/kind cleanup

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
