### PR TITLE
Add `initializingworkspaces` to list of providers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ This repository is expected to contain multiple [`Provider`](https://github.com/
 
 Currently available are:
 
-- [apiexport](./apiexport/): for interacting with the [`APIExport` virtual workspace](https://docs.kcp.io/kcp/latest/concepts/apis/exporting-apis/#build-your-controller) (or virtual workspaces with the same semantics).
+- [apiexport](https://pkg.go.dev/github.com/kcp-dev/multicluster-provider/apiexport): for interacting with the [`APIExport` virtual workspace](https://docs.kcp.io/kcp/latest/concepts/apis/exporting-apis/#build-your-controller) (or virtual workspaces with the same semantics).
+- [initializingworkspaces](https://pkg.go.dev/github.com/kcp-dev/multicluster-provider/initializingworkspaces): for interacting with logical clusters that are currently being [initialized](https://docs.kcp.io/kcp/latest/concepts/workspaces/workspace-initialization/) and wait for an initializer created by a `WorkspaceType` to be removed.
 
 ## Examples
 
-See [examples/apiexport](./examples/apiexport) for sample code.
+See [examples](./examples/) for sample code. All providers in this repository come with an example.
 
 ## Contributing
 


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Follow-up for #25. We didn't add it to documentation in our README. Also adding links to the go module docs on pkg.go.dev since that is more relevant for end users.

## What Type of PR Is This?

/kind documentation

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
