### PR TITLE
Add event recording capabilities to the `apiexport` provider

### DIFF
--- a/apiexport/provider.go
+++ b/apiexport/provider.go
@@ -19,6 +19,7 @@ package apiexport
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"sync"
 	"time"
 
@@ -29,6 +30,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	toolscache "k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -43,6 +45,7 @@ import (
 	"github.com/kcp-dev/logicalcluster/v3"
 
 	mcpcache "github.com/kcp-dev/multicluster-provider/internal/cache"
+	mcrecorder "github.com/kcp-dev/multicluster-provider/internal/events/recorder"
 )
 
 var _ multicluster.Provider = &Provider{}
@@ -62,6 +65,8 @@ type Provider struct {
 	lock      sync.RWMutex
 	clusters  map[logicalcluster.Name]cluster.Cluster
 	cancelFns map[logicalcluster.Name]context.CancelFunc
+
+	recorderProvider *mcrecorder.Provider
 }
 
 // Options are the options for creating a new instance of the apiexport provider.
@@ -81,6 +86,12 @@ type Options struct {
 	// against custom virtual workspaces that are not the APIExport one but share
 	// the same endpoint semantics.
 	ObjectToWatch client.Object
+
+	// makeBroadcaster allows deferring the creation of the broadcaster to
+	// avoid leaking goroutines if we never call Start on this manager.  It also
+	// returns whether or not this is an "owned" broadcaster, and as such should be
+	// stopped with the manager.
+	makeBroadcaster mcrecorder.EventBroadcasterProducer
 }
 
 // New creates a new kcp virtual workspace provider. The provided [rest.Config]
@@ -105,6 +116,15 @@ func New(cfg *rest.Config, options Options) (*Provider, error) {
 		options.ObjectToWatch = &apisv1alpha1.APIBinding{}
 	}
 
+	if options.makeBroadcaster == nil {
+		options.makeBroadcaster = makeBroadaster
+	}
+
+	recorderProvider, err := mcrecorder.NewProvider(cfg, http.DefaultClient, options.Scheme, log.Log.WithName("event-broadcaster"), options.makeBroadcaster)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Provider{
 		config: cfg,
 		scheme: options.Scheme,
@@ -115,7 +135,13 @@ func New(cfg *rest.Config, options Options) (*Provider, error) {
 
 		clusters:  map[logicalcluster.Name]cluster.Cluster{},
 		cancelFns: map[logicalcluster.Name]context.CancelFunc{},
+
+		recorderProvider: recorderProvider,
 	}, nil
+}
+
+func makeBroadaster() (record.EventBroadcaster, bool) {
+	return record.NewBroadcaster(), true
 }
 
 // Run starts the provider and blocks.
@@ -157,7 +183,7 @@ func (p *Provider) Run(ctx context.Context, mgr mcmanager.Manager) error {
 
 			// create new scoped cluster.
 			clusterCtx, cancel := context.WithCancel(ctx)
-			cl, err := mcpcache.NewScopedCluster(p.config, clusterName, p.cache, p.scheme)
+			cl, err := mcpcache.NewScopedCluster(p.config, clusterName, p.cache, p.scheme, p.recorderProvider)
 			if err != nil {
 				p.log.Error(err, "failed to create cluster", "cluster", clusterName)
 				cancel()
@@ -205,6 +231,14 @@ func (p *Provider) Run(ctx context.Context, mgr mcmanager.Manager) error {
 			}
 			if len(keys) == 0 {
 				p.lock.Lock()
+
+				// shut down individual event broadaster
+				if err := p.recorderProvider.StopBroadcaster(clusterName.String()); err != nil {
+					p.lock.Unlock()
+					p.log.Error(err, "failed to stop event broadcaster", "cluster", clusterName)
+					return
+				}
+
 				cancel, ok := p.cancelFns[clusterName]
 				if ok {
 					p.log.Info("disengaging cluster", "cluster", clusterName)
@@ -220,6 +254,17 @@ func (p *Provider) Run(ctx context.Context, mgr mcmanager.Manager) error {
 	}
 
 	g.Go(func() error { return p.cache.Start(ctx) })
+	g.Go(func() error {
+		// wait for context stop and try to shut down event broadcasters
+		select {
+		case <-ctx.Done():
+			shutdownCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			defer cancel()
+			p.recorderProvider.Stop(shutdownCtx)
+		default:
+		}
+		return nil
+	})
 
 	syncCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()

--- a/examples/apiexport/README.md
+++ b/examples/apiexport/README.md
@@ -16,7 +16,7 @@ workspace.tenancy.kcp.io/example3 created
 Then, start the example controller by passing the virtual workspace URL to it:
 
 ```sh
-$ go run . --server=$(kubectl get apiexport examples-apiexport-multicluster -o jsonpath="{.status.virtualWorkspaces[0].url}")
+$ go run . --server=$(kubectl get apiexportendpointslice examples-apiexport-multicluster -o jsonpath="{.status.virtualWorkspaces[0].url}")
 ```
 
 Observe the controller reconciling the `kube-root-ca.crt` ConfigMap created in each workspace:

--- a/examples/apiexport/main.go
+++ b/examples/apiexport/main.go
@@ -114,7 +114,7 @@ func main() {
 				}
 
 				log.Info("Reconciling ConfigMap", "name", s.Name, "uuid", s.UID)
-				recorder := cl.GetEventRecorderFor("kdp-configmap-controller")
+				recorder := cl.GetEventRecorderFor("kcp-configmap-controller")
 				recorder.Eventf(s, corev1.EventTypeNormal, "ConfigMap Reconciled", "ConfigMap %s reconciled", s.Name)
 
 				return reconcile.Result{}, nil

--- a/examples/apiexport/main.go
+++ b/examples/apiexport/main.go
@@ -114,6 +114,8 @@ func main() {
 				}
 
 				log.Info("Reconciling ConfigMap", "name", s.Name, "uuid", s.UID)
+				recorder := cl.GetEventRecorderFor("kdp-configmap-controller")
+				recorder.Eventf(s, corev1.EventTypeNormal, "ConfigMap Reconciled", "ConfigMap %s reconciled", s.Name)
 
 				return reconcile.Result{}, nil
 			},

--- a/examples/apiexport/manifests/bundle.yaml
+++ b/examples/apiexport/manifests/bundle.yaml
@@ -22,6 +22,9 @@ spec:
   - all: true
     group: ""
     resource: configmaps
+  - all: true
+    group: ""
+    resource: events
 ---
 apiVersion: tenancy.kcp.io/v1alpha1
 kind: WorkspaceType

--- a/hack/verify-boilerplate.sh
+++ b/hack/verify-boilerplate.sh
@@ -26,6 +26,7 @@ _tools/boilerplate \
   -boilerplates hack/boilerplate \
   -exclude .github \
   -exclude internal/cache/forked_cache_reader.go \
+  -exclude internal/events/recorder/forked_recorder.go \
   -exclude envtest
 _tools/boilerplate -boilerplates hack/boilerplate/kubernetes \
   -exclude envtest/doc.go \
@@ -33,7 +34,8 @@ _tools/boilerplate -boilerplates hack/boilerplate/kubernetes \
   -exclude envtest/scheme.go \
   -exclude envtest/testing.go \
   -exclude envtest/workspaces.go \
-  internal/cache/forked_cache_reader.go
+  internal/cache/forked_cache_reader.go \
+  internal/events/recorder/forked_recorder.go
 _tools/boilerplate \
   -boilerplates hack/boilerplate \
   envtest/doc.go \

--- a/internal/events/recorder/forked_recorder.go
+++ b/internal/events/recorder/forked_recorder.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package recorder
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+)
+
+// EventBroadcasterProducer makes an event broadcaster, returning
+// whether or not the broadcaster should be stopped with the Provider,
+// or not (e.g. if it's shared, it shouldn't be stopped with the Provider).
+type EventBroadcasterProducer func() (caster record.EventBroadcaster, stopWithProvider bool)
+
+// Provider is a recorder.Provider that records events to the k8s API server
+// and to a logr Logger.
+type Provider struct {
+	lock    sync.RWMutex
+	stopped bool
+
+	// scheme to specify when creating a recorder
+	scheme *runtime.Scheme
+	// logger is the logger to use when logging diagnostic event info
+	logger          logr.Logger
+	evtClient       corev1client.EventInterface
+	makeBroadcaster EventBroadcasterProducer
+
+	broadcasterOnce sync.Once
+	broadcaster     record.EventBroadcaster
+	stopBroadcaster bool
+}
+
+// NB(directxman12): this manually implements Stop instead of Being a runnable because we need to
+// stop it *after* everything else shuts down, otherwise we'll cause panics as the leader election
+// code finishes up and tries to continue emitting events.
+
+// Stop attempts to stop this provider, stopping the underlying broadcaster
+// if the broadcaster asked to be stopped.  It kinda tries to honor the given
+// context, but the underlying broadcaster has an indefinite wait that doesn't
+// return until all queued events are flushed, so this may end up just returning
+// before the underlying wait has finished instead of cancelling the wait.
+// This is Very Frustrating™.
+func (p *Provider) Stop(shutdownCtx context.Context) {
+	doneCh := make(chan struct{})
+
+	go func() {
+		// technically, this could start the broadcaster, but practically, it's
+		// almost certainly already been started (e.g. by leader election).  We
+		// need to invoke this to ensure that we don't inadvertently race with
+		// an invocation of getBroadcaster.
+		broadcaster := p.getBroadcaster()
+		if p.stopBroadcaster {
+			p.lock.Lock()
+			broadcaster.Shutdown()
+			p.stopped = true
+			p.lock.Unlock()
+		}
+		close(doneCh)
+	}()
+
+	select {
+	case <-shutdownCtx.Done():
+	case <-doneCh:
+	}
+}
+
+// getBroadcaster ensures that a broadcaster is started for this
+// provider, and returns it.  It's threadsafe.
+func (p *Provider) getBroadcaster() record.EventBroadcaster {
+	// NB(directxman12): this can technically still leak if something calls
+	// "getBroadcaster" (i.e. Emits an Event) but never calls Start, but if we
+	// create the broadcaster in start, we could race with other things that
+	// are started at the same time & want to emit events.  The alternative is
+	// silently swallowing events and more locking, but that seems suboptimal.
+
+	p.broadcasterOnce.Do(func() {
+		broadcaster, stop := p.makeBroadcaster()
+		broadcaster.StartRecordingToSink(&corev1client.EventSinkImpl{Interface: p.evtClient})
+		broadcaster.StartEventWatcher(
+			func(e *corev1.Event) {
+				p.logger.V(1).Info(e.Message, "type", e.Type, "object", e.InvolvedObject, "reason", e.Reason)
+			})
+		p.broadcaster = broadcaster
+		p.stopBroadcaster = stop
+	})
+
+	return p.broadcaster
+}
+
+// NewProvider create a new Provider instance.
+func NewProvider(config *rest.Config, httpClient *http.Client, scheme *runtime.Scheme, logger logr.Logger, makeBroadcaster EventBroadcasterProducer) (*Provider, error) {
+	if httpClient == nil {
+		panic("httpClient must not be nil")
+	}
+
+	corev1Client, err := corev1client.NewForConfigAndClient(config, httpClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init client: %w", err)
+	}
+
+	p := &Provider{scheme: scheme, logger: logger, makeBroadcaster: makeBroadcaster, evtClient: corev1Client.Events("")}
+	return p, nil
+}
+
+// GetEventRecorderFor returns an event recorder that broadcasts to this provider's
+// broadcaster.  All events will be associated with a component of the given name.
+func (p *Provider) GetEventRecorderFor(name string) record.EventRecorder {
+	return &lazyRecorder{
+		prov: p,
+		name: name,
+	}
+}
+
+// lazyRecorder is a recorder that doesn't actually instantiate any underlying
+// recorder until the first event is emitted.
+type lazyRecorder struct {
+	prov *Provider
+	name string
+
+	recOnce sync.Once
+	rec     record.EventRecorder
+}
+
+// ensureRecording ensures that a concrete recorder is populated for this recorder.
+func (l *lazyRecorder) ensureRecording() {
+	l.recOnce.Do(func() {
+		broadcaster := l.prov.getBroadcaster()
+		l.rec = broadcaster.NewRecorder(l.prov.scheme, corev1.EventSource{Component: l.name})
+	})
+}
+
+func (l *lazyRecorder) Event(object runtime.Object, eventtype, reason, message string) {
+	l.ensureRecording()
+
+	l.prov.lock.RLock()
+	if !l.prov.stopped {
+		l.rec.Event(object, eventtype, reason, message)
+	}
+	l.prov.lock.RUnlock()
+}
+func (l *lazyRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+	l.ensureRecording()
+
+	l.prov.lock.RLock()
+	if !l.prov.stopped {
+		l.rec.Eventf(object, eventtype, reason, messageFmt, args...)
+	}
+	l.prov.lock.RUnlock()
+}
+func (l *lazyRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	l.ensureRecording()
+
+	l.prov.lock.RLock()
+	if !l.prov.stopped {
+		l.rec.AnnotatedEventf(object, annotations, eventtype, reason, messageFmt, args...)
+	}
+	l.prov.lock.RUnlock()
+}

--- a/internal/events/recorder/recorder_test.go
+++ b/internal/events/recorder/recorder_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package recorder
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+)
+
+func TestEventBroadcasterProvider(t *testing.T) {
+	makeBroadcaster := func() (record.EventBroadcaster, bool) { return record.NewBroadcaster(), true }
+
+	provider, err := NewProvider(http.DefaultClient, scheme.Scheme, logr.Discard(), makeBroadcaster)
+	require.NoError(t, err)
+
+	recorder := provider.GetEventRecorderFor(&rest.Config{}, "test", "cluster")
+	recorder.Event(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "configmap", Namespace: "default"}}, corev1.EventTypeNormal, "reason", "message")
+	require.Len(t, provider.broadcasters, 1)
+
+	err = provider.StopBroadcaster("cluster")
+	require.NoError(t, err)
+	require.Len(t, provider.broadcasters, 0)
+}

--- a/test/e2e/initializingworkspaces_test.go
+++ b/test/e2e/initializingworkspaces_test.go
@@ -230,18 +230,24 @@ var _ = Describe("InitializingWorkspaces Provider", Ordered, func() {
 			}, wait.ForeverTestTimeout, time.Millisecond*100, "failed to see workspace %q engaged as a cluster: %v", ws2.Spec.Cluster, list())
 		})
 
+		listRemoved := func() []string {
+			initializersLock.RLock()
+			defer initializersLock.RUnlock()
+			return initializersRemoved.List()
+		}
+
 		It("removes initializers from the both clusters after engaging", func() {
 			envtest.Eventually(GinkgoT(), func() (bool, string) {
 				initializersLock.RLock()
 				defer initializersLock.RUnlock()
 				return initializersRemoved.Has(ws1.Spec.Cluster), fmt.Sprintf("failed to see removed initializer from %q cluster: %v", ws1.Spec.Cluster, initializersRemoved.List())
-			}, wait.ForeverTestTimeout, time.Millisecond*100, "failed to see removed initializer from %q cluster: %v", ws1.Spec.Cluster, initializersRemoved.List())
+			}, wait.ForeverTestTimeout, time.Millisecond*100, "failed to see removed initializer from %q cluster: %v", ws1.Spec.Cluster, listRemoved())
 
 			envtest.Eventually(GinkgoT(), func() (bool, string) {
 				initializersLock.RLock()
 				defer initializersLock.RUnlock()
 				return initializersRemoved.Has(ws2.Spec.Cluster), fmt.Sprintf("failed to see removed initializer from %q cluster: %v", ws2.Spec.Cluster, initializersRemoved.List())
-			}, wait.ForeverTestTimeout, time.Millisecond*100, "failed to see removed initializer from %q cluster: %v", ws2.Spec.Cluster, initializersRemoved.List())
+			}, wait.ForeverTestTimeout, time.Millisecond*100, "failed to see removed initializer from %q cluster: %v", ws2.Spec.Cluster, listRemoved())
 
 			By("checking if LogicalClusters objects have no initializers left")
 			var err error

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	eventsv1 "k8s.io/api/events/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -51,6 +52,7 @@ func init() {
 	runtime.Must(corev1alpha1.AddToScheme(scheme.Scheme))
 	runtime.Must(tenancyv1alpha1.AddToScheme(scheme.Scheme))
 	runtime.Must(topologyv1alpha1.AddToScheme(scheme.Scheme))
+	runtime.Must(eventsv1.AddToScheme(scheme.Scheme))
 }
 
 func TestE2e(t *testing.T) {


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Another attempt at solving #2, building on top of #28. This forks [recorder.go](https://github.com/kubernetes-sigs/controller-runtime/blob/main/pkg/internal/recorder/recorder.go) over from controller-runtime and makes the recorder provider capable of managing multiple broadcasters, one per cluster.

This is still WIP but looks like it's functional. More tests are needed.

One concern I would like to address somehow, and I believe this affects any reconciler written with multicluster-runtime: A common pattern with event broadcasters is that they are embedded in the `Reconciler` struct and loaded from there. That obviously doesn't work for multicluster controllers, since you don't know which event recorder you need. The obvious fix for that might be a map to hold references to them all, but it would be nice if we validated that.

The current example creates a new broadcaster in every reconciliation loop, which isn't ideal.

## What Type of PR Is This?

/kind feature

## Related Issue(s)

Fixes #2

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Implement `GetEventRecorderFor` for clusters returned by the `apiexport` provider
```
