### PR TITLE
Remove double `/clusters/` suffix in `initializingworkspaces` provider

### DIFF
--- a/initializingworkspaces/provider.go
+++ b/initializingworkspaces/provider.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"strings"
 	"sync"
 	"time"
 
@@ -228,12 +227,7 @@ func (p *Provider) handleLogicalClusterEvent(ctx context.Context, obj any, mgr m
 	clusterCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	cfg := rest.CopyConfig(p.config)
-	host := cfg.Host
-	host = strings.TrimSuffix(host, "/clusters/*")
-	cfg.Host = fmt.Sprintf("%s/clusters/%s", host, clusterName)
-
-	cl, err := mcpcache.NewScopedInitializingCluster(cfg, clusterName, p.wildcardCache, p.scheme)
+	cl, err := mcpcache.NewScopedInitializingCluster(p.config, clusterName, p.wildcardCache, p.scheme)
 	if err != nil {
 		p.log.Error(err, "failed to create cluster", "cluster", clusterName)
 		cancel()

--- a/test/e2e/initializingworkspaces_test.go
+++ b/test/e2e/initializingworkspaces_test.go
@@ -211,17 +211,23 @@ var _ = Describe("InitializingWorkspaces Provider", Ordered, func() {
 			})
 		})
 		It("engages both Logical Clusters with initializers", func() {
+			list := func() []string {
+				lock.RLock()
+				defer lock.RUnlock()
+				return engaged.List()
+			}
+
 			envtest.Eventually(GinkgoT(), func() (bool, string) {
 				lock.RLock()
 				defer lock.RUnlock()
 				return engaged.Has(ws1.Spec.Cluster), fmt.Sprintf("failed to see workspace %q engaged as a cluster: %v", ws1.Spec.Cluster, engaged.List())
-			}, wait.ForeverTestTimeout, time.Millisecond*100, "failed to see workspace %q engaged as a cluster: %v", ws1.Spec.Cluster, engaged.List())
+			}, wait.ForeverTestTimeout, time.Millisecond*100, "failed to see workspace %q engaged as a cluster: %v", ws1.Spec.Cluster, list())
 
 			envtest.Eventually(GinkgoT(), func() (bool, string) {
 				lock.RLock()
 				defer lock.RUnlock()
 				return engaged.Has(ws2.Spec.Cluster), fmt.Sprintf("failed to see workspace %q engaged as a cluster: %v", ws2.Spec.Cluster, engaged.List())
-			}, wait.ForeverTestTimeout, time.Millisecond*100, "failed to see workspace %q engaged as a cluster: %v", ws2.Spec.Cluster, engaged.List())
+			}, wait.ForeverTestTimeout, time.Millisecond*100, "failed to see workspace %q engaged as a cluster: %v", ws2.Spec.Cluster, list())
 		})
 
 		It("removes initializers from the both clusters after engaging", func() {


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

I was testing the providers against latest kcp `release-0.28` and tests for initializingworkspaces stopped working. The reason turned out to be that the provider was appending `/clusters/` two times, which is no longer working thanks to correctly parsing URLs in kcp (fixed in https://github.com/kcp-dev/kcp/pull/3548).

Therefore, this PR eliminates one of the instances of us appending the suffix to the URL. In addition, I ran into another data race because I forgot to put a read lock on the `engaged.List()` call in the eventually loop.

## What Type of PR Is This?

/kind bug


## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
initializingworkspaces: stop appending `/clusters/` suffix multiple times when creating scoped client
```
