### PR TITLE
Rework provider to use clusters.Clusters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.kubeconfig
 *.pem
 *.key
+.vscode/

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/kcp-dev/multicluster-provider
 
 go 1.24.0
 
+// Point to non-released version with clusters.Clusters support.
+replace sigs.k8s.io/multicluster-runtime => sigs.k8s.io/multicluster-runtime v0.21.0-alpha.9.0.20251120090003-9e4e256f374e
+
 require (
 	github.com/go-logr/logr v1.4.2
 	github.com/hashicorp/golang-lru/v2 v2.0.7

--- a/go.sum
+++ b/go.sum
@@ -220,8 +220,8 @@ sigs.k8s.io/controller-runtime v0.22.3 h1:I7mfqz/a/WdmDCEnXmSPm8/b/yRTy6JsKKENTi
 sigs.k8s.io/controller-runtime v0.22.3/go.mod h1:+QX1XUpTXN4mLoblf4tqr5CQcyHPAki2HLXqQMY6vh8=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 h1:gBQPwqORJ8d8/YNZWEjoZs7npUVDpVXUUOFfW6CgAqE=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
-sigs.k8s.io/multicluster-runtime v0.22.0-beta.0.0.20251118095141-e15a9cfac31a h1:lH+JyVZNN1nEkZCypZ1J+FmUr9lHTNnAhHqZ7maDtPY=
-sigs.k8s.io/multicluster-runtime v0.22.0-beta.0.0.20251118095141-e15a9cfac31a/go.mod h1:4e/q1PCYE75S76Fd4nrPY3cbnj1TXjnjYfJ5ysQyaMw=
+sigs.k8s.io/multicluster-runtime v0.21.0-alpha.9.0.20251120090003-9e4e256f374e h1:nk04FclLXfjWK685uO4N/fUdVjz0PNo4R6JFV1al+Uc=
+sigs.k8s.io/multicluster-runtime v0.21.0-alpha.9.0.20251120090003-9e4e256f374e/go.mod h1:4e/q1PCYE75S76Fd4nrPY3cbnj1TXjnjYfJ5ysQyaMw=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
 sigs.k8s.io/structured-merge-diff/v6 v6.3.0 h1:jTijUJbW353oVOd9oTlifJqOGEkUw2jB/fXCbTiQEco=

--- a/internal/cache/cluster.go
+++ b/internal/cache/cluster.go
@@ -18,7 +18,6 @@ package cache
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -183,5 +182,6 @@ func (c *ScopedCluster) GetAPIReader() client.Reader {
 
 // Start starts the cluster.
 func (c *ScopedCluster) Start(ctx context.Context) error {
-	return errors.New("scoped cluster cannot be started")
+	<-ctx.Done()
+	return nil
 }

--- a/internal/cache/forked_cache_reader.go
+++ b/internal/cache/forked_cache_reader.go
@@ -212,7 +212,7 @@ func byIndexes(indexer cache.Indexer, requires fields.Requirements, clusterName 
 	indexers := indexer.GetIndexers()
 	_, isClusterAware := indexers[kcpcache.ClusterAndNamespaceIndexName]
 	for idx, req := range requires {
-		indexName := fieldIndexName(isClusterAware, req.Field)
+		indexName := fieldIndexName(req.Field)
 		var indexedValue string
 		if isClusterAware {
 			indexedValue = keyToClusteredKey(clusterName.String(), namespace, req.Value)
@@ -270,10 +270,7 @@ func objectKeyToStoreKey(k client.ObjectKey) string {
 
 // fieldIndexName constructs the name of the index over the given field,
 // for use with an indexer.
-func fieldIndexName(clusterAware bool, field string) string {
-	if clusterAware {
-		return "field:cluster/" + field
-	}
+func fieldIndexName(field string) string {
 	return "field:" + field
 }
 


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

## What Type of PR Is This?

This moves the provider to use `clusters.Cluster` and in a way removes the need for the inner provider.
In the next PR, we will need to remove the inner provider and squash the code. But this is already big PR.

/kind feature
/kind api-change

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Migrate provider to use `clusters.Clusters`
```
