### PR TITLE
Unscrew dependency hell to bring back multicluster-runtime v0.22.4-beta.1

### DIFF
--- a/apiexport/internal/provider/provider.go
+++ b/apiexport/internal/provider/provider.go
@@ -39,8 +39,8 @@ import (
 	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
 
 	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
-	apisv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
 	"github.com/kcp-dev/logicalcluster/v3"
+	apisv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
 
 	mcpcache "github.com/kcp-dev/multicluster-provider/internal/cache"
 	mcrecorder "github.com/kcp-dev/multicluster-provider/internal/events/recorder"

--- a/envtest/workspaces.go
+++ b/envtest/workspaces.go
@@ -33,10 +33,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
+	"github.com/kcp-dev/logicalcluster/v3"
 	"github.com/kcp-dev/sdk/apis/core"
 	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
-	"github.com/kcp-dev/logicalcluster/v3"
 
 	kcpclient "github.com/kcp-dev/multicluster-provider/client"
 )

--- a/initializingworkspaces/provider.go
+++ b/initializingworkspaces/provider.go
@@ -38,8 +38,8 @@ import (
 
 	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
 
-	kcpcorev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 	"github.com/kcp-dev/logicalcluster/v3"
+	kcpcorev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 
 	mcpcache "github.com/kcp-dev/multicluster-provider/internal/cache"
 )

--- a/test/e2e/apiexport_test.go
+++ b/test/e2e/apiexport_test.go
@@ -46,11 +46,11 @@ import (
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
+	"github.com/kcp-dev/logicalcluster/v3"
 	apisv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
 	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
 	"github.com/kcp-dev/sdk/apis/core"
 	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
-	"github.com/kcp-dev/logicalcluster/v3"
 
 	"github.com/kcp-dev/multicluster-provider/apiexport"
 	clusterclient "github.com/kcp-dev/multicluster-provider/client"

--- a/test/e2e/initializingworkspaces_test.go
+++ b/test/e2e/initializingworkspaces_test.go
@@ -37,11 +37,11 @@ import (
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
+	"github.com/kcp-dev/logicalcluster/v3"
 	"github.com/kcp-dev/sdk/apis/core"
 	kcpcorev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 	"github.com/kcp-dev/sdk/apis/tenancy/initialization"
 	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
-	"github.com/kcp-dev/logicalcluster/v3"
 
 	clusterclient "github.com/kcp-dev/multicluster-provider/client"
 	"github.com/kcp-dev/multicluster-provider/envtest"


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

This reverts some changes in #56 by isolating the dependency pinning to the problematic package, the `logicalclusters` example. The problem with it is this line: https://github.com/kcp-dev/multicluster-provider/blob/06c8d131f28904fa37b3edabf94a9543ed6ecb71/examples/logicalclusters/main.go#L43

kcp client-go does indeed not play well with newer controller-runtime versions, but usually controller code doesn't use kcp client-go, so it should not affect normal consumers.

I would recommend we try to rewrite the example to avoid the kcp client-go dependency and then bring it up to newest dependencies.

## What Type of PR Is This?
/kind cleanup

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Update to multicluster-runtime v0.22.4-beta.1 and kcp 0.29.0
```
