### PR TITLE
update docs for apiexport example and new provider function

### DIFF
--- a/apiexport/provider.go
+++ b/apiexport/provider.go
@@ -88,9 +88,8 @@ type Options struct {
 }
 
 // New creates a new kcp virtual workspace provider. The provided [rest.Config]
-// must point to a virtual workspace apiserver base path, i.e. up to but without
-// the '/clusters/*' suffix. This information can be extracted from the APIExport
-// status (deprecated) or an APIExportEndpointSlice status.
+// must point to a logical workspace apiserver base path. The virtual workspace
+// url is extract via the endpointSliceName and must not be set in the config as host.
 func New(cfg *rest.Config, endpointSliceName string, options Options) (*Provider, error) {
 	// Do the defaulting controller-runtime would do for those fields we need.
 	if options.Scheme == nil {

--- a/examples/apiexport/README.md
+++ b/examples/apiexport/README.md
@@ -16,7 +16,7 @@ workspace.tenancy.kcp.io/example3 created
 Then, start the example controller by passing the virtual workspace URL to it:
 
 ```sh
-$ go run . --server=$(kubectl get apiexportendpointslice examples-apiexport-multicluster -o jsonpath="{.status.endpoints[0].url}")
+$ go run . --endpointslice=examples-apiexport-multicluster
 ```
 
 Observe the controller reconciling the `kube-root-ca.crt` ConfigMap created in each workspace:


### PR DESCRIPTION
## Summary
The documentation for the apiexport example and the apiexport provider function `New()` are corrected.

## What Type of PR Is This?
/kind documentation

## Related Issue(s)

Fixes #

## Release Notes
```release-note
NONE
```
