### PR TITLE
Consolidate provider factories

### DIFF
--- a/initializingworkspaces/provider.go
+++ b/initializingworkspaces/provider.go
@@ -17,21 +17,14 @@ limitations under the License.
 package initializingworkspaces
 
 import (
-	"context"
-	"crypto/sha256"
-	"encoding/hex"
-	"fmt"
 	"strings"
-	"sync"
 
 	"github.com/go-logr/logr"
-	"golang.org/x/sync/errgroup"
 
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	toolscache "k8s.io/client-go/tools/cache"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -60,20 +53,7 @@ var _ multicluster.ProviderRunnable = &Provider{}
 //
 // [logical cluster]: https://docs.kcp.io/kcp/latest/concepts/terminology/#logical-cluster
 type Provider struct {
-	clusters *provider.Clusters
-	aware    multicluster.Aware
-	context  context.Context
-
-	providersLock sync.RWMutex
-	providers     map[string]*provider.Provider
-
-	log      logr.Logger
-	handlers handlers.Handlers
-
-	config *rest.Config
-	scheme *runtime.Scheme
-	object client.Object
-	cache  cache.Cache
+	provider.Factory
 }
 
 // Options are the options for creating a new instance of the initializing workspaces provider.
@@ -127,164 +107,38 @@ func New(cfg *rest.Config, workspaceTypeName string, options Options) (*Provider
 	}
 
 	return &Provider{
-		// func to pass into iner provider to lifecycle clusters
-		clusters:  ptr.To(clusters.New[cluster.Cluster]()),
-		providers: map[string]*provider.Provider{},
+		Factory: provider.Factory{
+			Clusters:  ptr.To(clusters.New[cluster.Cluster]()),
+			Providers: map[string]*provider.Provider{},
 
-		config: cfg,
-		scheme: options.Scheme,
-		object: options.ObjectToWatch,
-		cache:  c,
+			Log:      *options.Log,
+			Handlers: options.Handlers,
 
-		log:      *options.Log,
-		handlers: options.Handlers,
-	}, nil
-}
+			GetVWs: func(obj client.Object) ([]string, error) {
+				wst := obj.(*kcptenancyv1alpha1.WorkspaceType)
+				var urls []string
+				for _, endpoint := range wst.Status.VirtualWorkspaces {
+					// The slice contains both the URLs for the initializingworkspaces and the
+					// terminatingworkspaces virtual workspace, so we need to filter.
+					if !strings.Contains(endpoint.URL, "/initializingworkspaces/") {
+						continue
+					}
+					urls = append(urls, endpoint.URL)
+				}
+				return urls, nil
+			},
 
-// Start starts the provider and blocks.
-func (p *Provider) Start(ctx context.Context, aware multicluster.Aware) error {
-	p.aware = aware
-	p.context = ctx
-	// Create a child context we can cancel when the WorkspaceType goes away.
-	ctx, cancel := context.WithCancel(ctx)
-
-	informer, err := p.cache.GetInformer(ctx, &kcptenancyv1alpha1.WorkspaceType{})
-	if err != nil {
-		cancel()
-		return err
-	}
-
-	handler, err := informer.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj any) {
-			wst := obj.(*kcptenancyv1alpha1.WorkspaceType)
-			p.log.Info("added WorkspaceType", "name", wst.Name)
-			p.update(wst)
-		},
-		UpdateFunc: func(oldObj any, newObj any) {
-			wst := newObj.(*kcptenancyv1alpha1.WorkspaceType)
-			p.log.Info("updated WorkspaceType", "name", wst.Name)
-			p.update(wst)
-		},
-		DeleteFunc: func(obj any) {
-			p.log.Info("deleted WorkspaceType, stopping provider")
-			cancel()
-		},
-	})
-	if err != nil {
-		return err
-	}
-
-	g, ctx := errgroup.WithContext(ctx)
-
-	g.Go(func() error {
-		<-ctx.Done()
-		err := informer.RemoveEventHandler(handler)
-		p.log.Info("removed cache event handler")
-		return err
-	})
-
-	g.Go(func() error {
-		err := p.cache.Start(ctx)
-		p.log.Info("cache stopped")
-		return err
-	})
-
-	if !p.cache.WaitForCacheSync(ctx) {
-		return fmt.Errorf("failed to wait for sync")
-	}
-
-	p.log.V(4).Info("caches have synced")
-
-	return g.Wait()
-}
-
-// update will look into the given WorkspaceType and ensure that providers
-// are initiated for every URL. It reads every URL and sets up a provider if needed for it,
-// and registers it inside current map. Finally, it cleans up any providers that are no longer
-// present in the endpoint slice (present in the providers but not in the current map).
-func (p *Provider) update(wst *kcptenancyv1alpha1.WorkspaceType) {
-	p.providersLock.Lock()
-	defer p.providersLock.Unlock()
-
-	if p.aware == nil {
-		p.log.Info("aware is not set yet, skipping update")
-		return
-	}
-
-	var current = make(map[string]bool) // currently registered providers
-
-	for _, endpoint := range wst.Status.VirtualWorkspaces {
-		// The slice contains both the URLs for the initializingworkspaces and the
-		// terminatingworkspaces virtual workspace, so we need to filter.
-		if !strings.Contains(endpoint.URL, "/initializingworkspaces/") {
-			continue
-		}
-
-		id := hashURL(endpoint.URL)
-		current[id] = true
-
-		// Skip already registered endpoints.
-		if _, exists := p.providers[id]; exists {
-			continue
-		}
-
-		// Start provider if we didn't have it registered before.
-		// Else, we just mark that we found it (for cleaning up outdated providers later).
-		cfg := rest.CopyConfig(p.config)
-		cfg.Host = endpoint.URL
-
-		logger := p.log.WithValues("url", endpoint.URL)
-		prov, err := provider.New(cfg, p.clusters, provider.Options{
-			ObjectToWatch: p.object,
-			Scheme:        p.scheme,
-			Log:           &logger,
-			Handlers:      p.handlers,
-
+			Config: cfg,
+			Scheme: options.Scheme,
+			Outer:  &kcptenancyv1alpha1.WorkspaceType{},
+			Inner:  options.ObjectToWatch,
+			Cache:  c,
 			// ensure the generic provider builds a per-cluster cache instead of a wildcard-based
 			// cache, since this virtual workspace does not offer anything but logicalclusters on
 			// the wildcard endpoint
 			NewCluster: func(cfg *rest.Config, clusterName logicalcluster.Name, wildcardCA mcpcache.WildcardCache, scheme *runtime.Scheme, _ *recorder.Provider) (*mcpcache.ScopedCluster, error) {
 				return mcpcache.NewScopedInitializingCluster(cfg, clusterName, wildcardCA, scheme)
 			},
-		})
-		if err != nil {
-			p.log.Error(err, "failed to create provider")
-			continue
-		}
-
-		err = prov.Start(p.context, p.aware)
-		if err != nil {
-			p.log.Error(err, "failed to start provider")
-			continue
-		}
-
-		p.providers[id] = prov
-		current[id] = true
-	}
-
-	// Clean up providers that are no longer present in the endpoint slice.
-	for id := range p.providers {
-		if _, exists := current[id]; exists {
-			continue
-		}
-		p.log.Info("stopping provider for removed endpoint", "id", id)
-		delete(p.providers, id)
-	}
-}
-
-// Get returns the cluster with the given name as a cluster.Cluster.
-func (p *Provider) Get(ctx context.Context, clusterName string) (cluster.Cluster, error) {
-	return p.clusters.Get(ctx, clusterName)
-}
-
-// IndexField adds an indexer to the clusters managed by this provider.
-func (p *Provider) IndexField(ctx context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error {
-	return p.clusters.IndexField(ctx, obj, field, extractValue)
-}
-
-// hashURL hashes an URL from an WorkspaceType status.
-func hashURL(url string) string {
-	sha := sha256.New()
-	sha.Write([]byte(url))
-	return hex.EncodeToString(sha.Sum(nil))[:8]
+		},
+	}, nil
 }

--- a/pkg/provider/factory.go
+++ b/pkg/provider/factory.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/go-logr/logr"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	toolscache "k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+
+	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
+
+	mcpcache "github.com/kcp-dev/multicluster-provider/pkg/cache"
+	"github.com/kcp-dev/multicluster-provider/pkg/handlers"
+)
+
+// Factory generates Providers
+type Factory struct {
+	Clusters *Clusters
+
+	Providers map[string]*Provider
+
+	Log      logr.Logger
+	Handlers handlers.Handlers
+
+	GetVWs func(obj client.Object) ([]string, error)
+
+	Config        *rest.Config
+	Scheme        *runtime.Scheme
+	Outer, Inner  client.Object
+	Cache         cache.Cache
+	WildcardCache mcpcache.WildcardCache
+	NewCluster    NewClusterFunc
+}
+
+// Get returns the cluster with the given name as a cluster.Cluster.
+func (f *Factory) Get(ctx context.Context, clusterName string) (cluster.Cluster, error) {
+	return f.Clusters.Get(ctx, clusterName)
+}
+
+// IndexField adds an indexer to the clusters managed by this provider.
+func (f *Factory) IndexField(ctx context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error {
+	return f.Clusters.IndexField(ctx, obj, field, extractValue)
+}
+
+// Start starts watching for objects of type T.
+func (f *Factory) Start(ctx context.Context, aware multicluster.Aware) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	if f.GetVWs == nil {
+		return fmt.Errorf("auxiliary function to retrieve virtual workspace URLs is unset")
+	}
+
+	informer, err := f.Cache.GetInformer(ctx, f.Outer)
+	if err != nil {
+		cancel()
+		return err
+	}
+
+	handler, err := informer.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			t := obj.(client.Object)
+			f.Log.Info("detected new object", "object", t)
+			f.update(ctx, aware, t)
+		},
+		UpdateFunc: func(oldObj any, newObj any) {
+			t := newObj.(client.Object)
+			f.Log.Info("detected updated object", "object", t)
+			f.update(ctx, aware, t)
+		},
+		DeleteFunc: func(obj any) {
+			f.Log.Info("detected deleted object, stopping all providers", "object", obj)
+			cancel()
+		},
+	})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := informer.RemoveEventHandler(handler); err != nil {
+			f.Log.Error(err, "failed to remove event handler")
+		}
+	}()
+
+	f.Log.Info("starting factory")
+	return f.Cache.Start(ctx)
+}
+
+func (f *Factory) update(ctx context.Context, aware multicluster.Aware, obj client.Object) {
+	var current = make(map[string]bool) // currently registered providers
+
+	if f.GetVWs == nil {
+		f.Log.Error(nil, "auxiliary function to retrieve virtual workspace URLs is unset")
+		return
+	}
+
+	vws, err := f.GetVWs(obj)
+	if err != nil {
+		f.Log.Error(err, "failed to get virtual workspace URLs")
+		return
+	}
+
+	for _, vw := range vws {
+		id := hashString(vw)
+		current[id] = true
+
+		// Skip already registered endpoints.
+		if _, exists := f.Providers[id]; exists {
+			continue
+		}
+
+		// Start provider if we didn't have it registered before.
+		// Else, we just mark that we found it (for cleaning up outdated providers later).
+		cfg := rest.CopyConfig(f.Config)
+		cfg.Host = vw
+
+		logger := f.Log.WithValues("url", vw)
+		prov, err := New(cfg, f.Clusters, Options{
+			ObjectToWatch: f.Inner,
+			Scheme:        f.Scheme,
+			Log:           &logger,
+			Handlers:      f.Handlers,
+			WildcardCache: f.WildcardCache,
+			NewCluster:    f.NewCluster,
+		})
+		if err != nil {
+			f.Log.Error(err, "failed to create provider")
+			continue
+		}
+
+		if err := prov.Start(ctx, aware); err != nil {
+			f.Log.Error(err, "failed to start provider")
+			continue
+		}
+
+		f.Providers[id] = prov
+		current[id] = true
+	}
+
+	// Clean up providers that are no longer present in the endpoint slice.
+	for id := range f.Providers {
+		if _, exists := current[id]; exists {
+			continue
+		}
+		f.Log.Info("stopping provider for removed endpoint", "id", id)
+		delete(f.Providers, id)
+	}
+}
+
+func hashString(s string) string {
+	sha := sha256.New()
+	sha.Write([]byte(s))
+	return hex.EncodeToString(sha.Sum(nil))[:8]
+}


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

I was reading the apiexport and initializingworkspaces providers and noticed that they were virtually identical with very minor differences.

Additionaly at some point we will have a terminatingworkspaces provider that also almost the same code again.

This is a first draft to add a `Factory` next to the `Provider` that watches CRs with VW URLs in the status.

I'm not 100% happy with the code yet, I just hacked this together because it bothered me.
Also tried using generics until I hit the pointer-reference-generic thing :D 

## What Type of PR Is This?

/kind cleanup

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
