### PR TITLE
Access to WildcardCache

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -306,3 +306,8 @@ func (p *Provider) Start(ctx context.Context, aware multicluster.Aware) error {
 
 	return g.Wait()
 }
+
+// GetCache provides access to the provider specific instance of the WildcardCache.
+func (p *Provider) GetCache() mcpcache.WildcardCache {
+	return p.cache
+}


### PR DESCRIPTION


## Summary

The KCP Provider uses public variables to access the shard-specific Provider objects, which
hold a specific instance of a WildcardCache.
This cache could be used to implement a KCP-wide object or index access.
Because the Provider is already publicly available, there does not seem to be a reason why the
wildcard cache should not be accessible.

This PR provides a public method `GetCache()` to access the cache.


## What Type of PR Is This?
/kind feature
<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
