### PR TITLE
fix: adapt to multicluster-runtime v0.23.3 ClusterName type change

### DIFF
--- a/examples/path-aware/main.go
+++ b/examples/path-aware/main.go
@@ -36,6 +36,7 @@ import (
 
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
+	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
 	apisv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
@@ -144,7 +145,7 @@ func main() {
 					log.Info("APIBinding logical cluster path", "path", canonicalPath)
 
 					// We should be able to resolve cluster object via path as well
-					clPath, err := mgr.GetCluster(ctx, canonicalPath)
+					clPath, err := mgr.GetCluster(ctx, multicluster.ClusterName(canonicalPath))
 					if err != nil {
 						log.Error(err, "failed to get cluster by path", "path", canonicalPath)
 						continue

--- a/go.mod
+++ b/go.mod
@@ -24,8 +24,8 @@ require (
 	k8s.io/client-go v0.35.0
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
-	sigs.k8s.io/controller-runtime v0.23.1
-	sigs.k8s.io/multicluster-runtime v0.23.1
+	sigs.k8s.io/controller-runtime v0.23.3
+	sigs.k8s.io/multicluster-runtime v0.23.3
 	sigs.k8s.io/yaml v1.6.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -209,12 +209,12 @@ k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 h1:Y3gxNAuB0OBLImH611+UDZ
 k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912/go.mod h1:kdmbQkyfwUagLfXIad1y2TdrjPFWp2Q89B3qkRwf/pQ=
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 h1:SjGebBtkBqHFOli+05xYbK8YF1Dzkbzn+gDM4X9T4Ck=
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-sigs.k8s.io/controller-runtime v0.23.1 h1:TjJSM80Nf43Mg21+RCy3J70aj/W6KyvDtOlpKf+PupE=
-sigs.k8s.io/controller-runtime v0.23.1/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
+sigs.k8s.io/controller-runtime v0.23.3 h1:VjB/vhoPoA9l1kEKZHBMnQF33tdCLQKJtydy4iqwZ80=
+sigs.k8s.io/controller-runtime v0.23.3/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
-sigs.k8s.io/multicluster-runtime v0.23.1 h1:isjVh6zBuk/U1HjYm22knRZmFsn6sFinmyvV+/4puCc=
-sigs.k8s.io/multicluster-runtime v0.23.1/go.mod h1:ri1Gvx7Qehy5nis6OnTgSpJIWaf2SuorHDwF/jvbWvM=
+sigs.k8s.io/multicluster-runtime v0.23.3 h1:vrzlXRzHTDsjspUAfoW2rCtr0agoI4q20p9x4Fz4png=
+sigs.k8s.io/multicluster-runtime v0.23.3/go.mod h1:r/UA4GHgFoXCcR4tcvlZz7SiLx3l1kJKDuBAhILNIHs=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
 sigs.k8s.io/structured-merge-diff/v6 v6.3.2-0.20260122202528-d9cc6641c482 h1:2WOzJpHUBVrrkDjU4KBT8n5LDcj824eX0I5UKcgeRUs=

--- a/path-aware/provider.go
+++ b/path-aware/provider.go
@@ -70,10 +70,10 @@ func New(cfg *rest.Config, endpointSliceName string, options provider.Options) (
 }
 
 // Get returns the cluster with the given name as a cluster.Cluster.
-func (p *Provider) Get(ctx context.Context, clusterName string) (cluster.Cluster, error) {
+func (p *Provider) Get(ctx context.Context, clusterName multicluster.ClusterName) (cluster.Cluster, error) {
 	if p.pathStore != nil {
-		if lcName, exists := p.pathStore.Get(clusterName); exists {
-			clusterName = lcName.String()
+		if lcName, exists := p.pathStore.Get(string(clusterName)); exists {
+			clusterName = multicluster.ClusterName(lcName.String())
 		}
 	}
 	return p.Provider.Get(ctx, clusterName)

--- a/pkg/provider/factory.go
+++ b/pkg/provider/factory.go
@@ -60,7 +60,7 @@ type Factory struct {
 }
 
 // Get returns the cluster with the given name as a cluster.Cluster.
-func (f *Factory) Get(ctx context.Context, clusterName string) (cluster.Cluster, error) {
+func (f *Factory) Get(ctx context.Context, clusterName multicluster.ClusterName) (cluster.Cluster, error) {
 	return f.Clusters.Get(ctx, clusterName)
 }
 

--- a/pkg/provider/factory_test.go
+++ b/pkg/provider/factory_test.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 
 	"sigs.k8s.io/multicluster-runtime/pkg/clusters"
+	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
 
 	"github.com/kcp-dev/logicalcluster/v3"
 
@@ -62,13 +63,7 @@ func (mockCache *mockCache) Start(ctx context.Context) error {
 
 type mockAware struct{}
 
-func (m *mockAware) AddCluster(ctx context.Context, name string) error {
-	return nil
-}
-
-func (m *mockAware) RemoveCluster(name string) {}
-
-func (m *mockAware) Engage(ctx context.Context, name string, clstr cluster.Cluster) error {
+func (m *mockAware) Engage(ctx context.Context, name multicluster.ClusterName, clstr cluster.Cluster) error {
 	return nil
 }
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -172,7 +172,7 @@ func New(cfg *rest.Config, clusters *Clusters, options Options) (*Provider, erro
 }
 
 // Get implements multicluster.Provider.
-func (p *Provider) Get(ctx context.Context, clusterName string) (cluster.Cluster, error) {
+func (p *Provider) Get(ctx context.Context, clusterName multicluster.ClusterName) (cluster.Cluster, error) {
 	return p.clusters.Get(ctx, clusterName)
 }
 
@@ -270,7 +270,7 @@ func (p *Provider) Setup(ctx context.Context, aware multicluster.Aware) error {
 
 				if ok {
 					p.log.Info("disengaging cluster", "cluster", clusterName)
-					p.clusters.Remove(clusterName.String())
+					p.clusters.Remove(multicluster.ClusterName(clusterName.String()))
 					p.handlers.RunOnDelete(cobj)
 				}
 			}
@@ -291,7 +291,7 @@ func (p *Provider) updateCluster(ctx context.Context, obj client.Object, aware m
 	clusterName := logicalcluster.From(obj)
 
 	// check if cluster already exists before creating. There is small chance for race but its ok.
-	if _, err := p.clusters.Get(ctx, clusterName.String()); err == nil {
+	if _, err := p.clusters.Get(ctx, multicluster.ClusterName(clusterName.String())); err == nil {
 		return fmt.Errorf("cluster %q already exists, skipping creation", clusterName)
 	}
 
@@ -306,7 +306,7 @@ func (p *Provider) updateCluster(ctx context.Context, obj client.Object, aware m
 		return fmt.Errorf("failed to create cluster %q: %w", clusterName, err)
 	}
 
-	if err := p.clusters.Add(ctx, clusterName.String(), cl, aware); err != nil {
+	if err := p.clusters.Add(ctx, multicluster.ClusterName(clusterName.String()), cl, aware); err != nil {
 		return fmt.Errorf("failed to add cluster %q: %w", clusterName, err)
 	}
 

--- a/test/e2e/apiexport_test.go
+++ b/test/e2e/apiexport_test.go
@@ -44,6 +44,7 @@ import (
 
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
+	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
 	"github.com/kcp-dev/logicalcluster/v3"
@@ -354,7 +355,7 @@ var _ = Describe("APIExport Provider", Ordered, func() {
 					By(fmt.Sprintf("reconciling APIBinding %s in cluster %q", request.Name, request.ClusterName))
 					lock.Lock()
 					defer lock.Unlock()
-					engaged.Insert(request.ClusterName)
+					engaged.Insert(string(request.ClusterName))
 
 					cluster, err := mgr.GetCluster(ctx, request.ClusterName)
 					if err != nil {
@@ -368,12 +369,12 @@ var _ = Describe("APIExport Provider", Ordered, func() {
 					}
 
 					eventLock.RLock()
-					recorder, ok := eventRecorders[request.ClusterName]
+					recorder, ok := eventRecorders[string(request.ClusterName)]
 					if !ok {
 						eventLock.RUnlock()
 						eventLock.Lock()
-						recorder = cluster.GetEventRecorder(request.ClusterName)
-						eventRecorders[request.ClusterName] = recorder
+						recorder = cluster.GetEventRecorder(string(request.ClusterName))
+						eventRecorders[string(request.ClusterName)] = recorder
 						eventLock.Unlock()
 					}
 
@@ -405,7 +406,7 @@ var _ = Describe("APIExport Provider", Ordered, func() {
 			envtest.Eventually(GinkgoT(), func() (success bool, reason string) {
 				l := &unstructured.UnstructuredList{}
 				l.SetGroupVersionKind(runtimeschema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "ThingList"})
-				consumerCl, err := mgr.GetCluster(ctx, consumerWS.Spec.Cluster)
+				consumerCl, err := mgr.GetCluster(ctx, multicluster.ClusterName(consumerWS.Spec.Cluster))
 				Expect(err).NotTo(HaveOccurred())
 
 				err = consumerCl.GetCache().List(ctx, l)
@@ -422,7 +423,7 @@ var _ = Describe("APIExport Provider", Ordered, func() {
 		})
 
 		It("sees only the stone as grey thing in the consumer clusters", func() {
-			consumerCl, err := mgr.GetCluster(ctx, consumerWS.Spec.Cluster)
+			consumerCl, err := mgr.GetCluster(ctx, multicluster.ClusterName(consumerWS.Spec.Cluster))
 			Expect(err).NotTo(HaveOccurred())
 			envtest.Eventually(GinkgoT(), func() (success bool, reason string) {
 				l := &unstructured.UnstructuredList{}

--- a/test/e2e/initializingworkspaces_test.go
+++ b/test/e2e/initializingworkspaces_test.go
@@ -162,7 +162,7 @@ var _ = Describe("InitializingWorkspaces Provider", Ordered, func() {
 						}
 
 						lock.Lock()
-						engaged.Insert(request.ClusterName)
+						engaged.Insert(string(request.ClusterName))
 						lock.Unlock()
 						initializer := kcpcorev1alpha1.LogicalClusterInitializer(initName)
 
@@ -175,7 +175,7 @@ var _ = Describe("InitializingWorkspaces Provider", Ordered, func() {
 								return reconcile.Result{}, err
 							}
 							initializersLock.Lock()
-							initializersRemoved.Insert(request.ClusterName)
+							initializersRemoved.Insert(string(request.ClusterName))
 							initializersLock.Unlock()
 						}
 						return reconcile.Result{}, nil


### PR DESCRIPTION
## Summary

- Bump `sigs.k8s.io/multicluster-runtime` v0.23.1 → v0.23.3 (and `controller-runtime` v0.23.1 → v0.23.3)
- Update `Provider.Get` and `Factory.Get` signatures to accept `multicluster.ClusterName` instead of `string`
- Convert internal `clusters.Get/Add/Remove` calls to use `multicluster.ClusterName`
- Update `path-aware` provider to match the new interface
- Fix test mocks (`mockAware.Engage`) and e2e tests for the new `Aware` interface

```release-note
Adapt to multicluster-runtime v0.23.3 ClusterName type change in Provider and Factory interfaces.
```