### PR TITLE
fix: add OnUpdate implementation for pathaware provider

### DIFF
--- a/path-aware/provider.go
+++ b/path-aware/provider.go
@@ -54,7 +54,8 @@ func New(cfg *rest.Config, endpointSliceName string, options provider.Options) (
 	store := paths.New()
 
 	h := &pathHandler{
-		pathStore: store,
+		pathStore:       store,
+		registeredPaths: make(map[string]struct{}),
 	}
 	options.Handlers = append(options.Handlers, h)
 
@@ -91,6 +92,8 @@ func (p *Provider) Start(ctx context.Context, aware multicluster.Aware) error {
 
 type pathHandler struct {
 	pathStore *paths.Store
+	// registeredPaths tracks which paths have already been added to pathStore
+	registeredPaths map[string]struct{}
 }
 
 func (p *pathHandler) OnAdd(obj client.Object) {
@@ -102,10 +105,23 @@ func (p *pathHandler) OnAdd(obj client.Object) {
 	}
 
 	p.pathStore.Add(path, cluster)
+	p.registeredPaths[path] = struct{}{}
 }
 
 func (p *pathHandler) OnUpdate(oldObj, newObj client.Object) {
-	// Not used.
+	newPath := newObj.GetAnnotations()[kcpcore.LogicalClusterPathAnnotationKey]
+
+	if newPath == "" {
+		return
+	}
+
+	if _, exists := p.registeredPaths[newPath]; exists {
+		return
+	}
+
+	cluster := logicalcluster.From(newObj)
+	p.pathStore.Add(newPath, cluster)
+	p.registeredPaths[newPath] = struct{}{}
 }
 
 func (p *pathHandler) OnDelete(obj client.Object) {
@@ -115,4 +131,5 @@ func (p *pathHandler) OnDelete(obj client.Object) {
 	}
 
 	p.pathStore.Remove(path)
+	delete(p.registeredPaths, path)
 }


### PR DESCRIPTION
On-behalf-of: SAP aleh.yarshou@sap.com

<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

This pr fixes the case, when logical cluster has been added into provider's Clusters set, but hasn't been added into pathStore in pathaware provider. It happens because when logical cluster is created, provider gets Add event but cluster isn't Ready and therefore is filtered out. After it provider get Update events and skips them due to unimplemented OnUpdate method. 

PR adds implementation of OnUpdate method for pathaware provider

## What Type of PR Is This?
/kind bug

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes  https://github.com/kcp-dev/multicluster-provider/issues/103

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
