### PR TITLE
feat: add GetSharedInformers for aggregate cache

### DIFF
--- a/pkg/cache/aggregate.go
+++ b/pkg/cache/aggregate.go
@@ -19,12 +19,12 @@ package cache
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
-	toolscache "k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -37,27 +37,64 @@ type Lister interface {
 type AggregateCache struct {
 	lock   sync.RWMutex
 	caches map[string]WildcardCache
+
+	// Track aggregate informers for dynamic shard updates
+	informersLock sync.RWMutex
+	informers     map[reflect.Type]*aggregateSharedIndexInformer
 }
 
 // NewAggregateCache returns an initialized AggregateCache.
 func NewAggregateCache() *AggregateCache {
 	return &AggregateCache{
-		caches: make(map[string]WildcardCache),
+		caches:    make(map[string]WildcardCache),
+		informers: make(map[reflect.Type]*aggregateSharedIndexInformer),
 	}
 }
 
 // AddCache registers a WildcardCache under the given id.
 func (a *AggregateCache) AddCache(id string, c WildcardCache) {
 	a.lock.Lock()
-	defer a.lock.Unlock()
 	a.caches[id] = c
+	a.lock.Unlock()
+
+	// Notify all aggregate informers to register their handlers with the new shard
+	a.informersLock.RLock()
+	for _, inf := range a.informers {
+		inf.onCacheAdded(id, c)
+	}
+	a.informersLock.RUnlock()
 }
 
 // RemoveCache unregisters the WildcardCache with the given id.
 func (a *AggregateCache) RemoveCache(id string) {
 	a.lock.Lock()
-	defer a.lock.Unlock()
 	delete(a.caches, id)
+	a.lock.Unlock()
+
+	// Notify all aggregate informers to clean up registrations for this shard
+	a.informersLock.RLock()
+	for _, inf := range a.informers {
+		inf.onCacheRemoved(id)
+	}
+	a.informersLock.RUnlock()
+}
+
+// GetAggregateInformer returns an AggregateSharedIndexInformer for the given object type.
+// The returned informer aggregates events from all current and future shards.
+// Calling this method multiple times with the same object type returns the same informer instance.
+func (a *AggregateCache) GetAggregateInformer(obj runtime.Object) AggregateSharedIndexInformer {
+	objType := reflect.TypeOf(obj)
+
+	a.informersLock.Lock()
+	defer a.informersLock.Unlock()
+
+	if inf, ok := a.informers[objType]; ok {
+		return inf
+	}
+
+	inf := newAggregateSharedIndexInformer(a, obj)
+	a.informers[objType] = inf
+	return inf
 }
 
 // List aggregates results from all registered caches.
@@ -96,21 +133,4 @@ func (a *AggregateCache) List(ctx context.Context, list client.ObjectList, opts 
 	}
 
 	return kerrors.NewAggregate(errs)
-}
-
-// GetSharedInformers returns SharedIndexInformers for all registered shard caches.
-// Users can use these informers to register event handlers across all shards.
-func (a *AggregateCache) GetSharedInformers(obj runtime.Object) ([]toolscache.SharedIndexInformer, error) {
-	a.lock.RLock()
-	defer a.lock.RUnlock()
-
-	result := make([]toolscache.SharedIndexInformer, 0, len(a.caches))
-	for id, c := range a.caches {
-		inf, _, _, err := c.GetSharedInformer(obj)
-		if err != nil {
-			return nil, fmt.Errorf("shard %q: %w", id, err)
-		}
-		result = append(result, inf)
-	}
-	return result, nil
 }

--- a/pkg/cache/aggregate.go
+++ b/pkg/cache/aggregate.go
@@ -19,13 +19,14 @@ package cache
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
 // Lister can list objects across all registered shard caches.
@@ -35,19 +36,22 @@ type Lister interface {
 
 // AggregateCache provides an aggregated view across multiple per-shard WildcardCaches.
 type AggregateCache struct {
+	scheme *runtime.Scheme
+
 	lock   sync.RWMutex
 	caches map[string]WildcardCache
 
 	// Track aggregate informers for dynamic shard updates
 	informersLock sync.RWMutex
-	informers     map[reflect.Type]*aggregateSharedIndexInformer
+	informers     map[schema.GroupVersionKind]*aggregateSharedIndexInformer
 }
 
 // NewAggregateCache returns an initialized AggregateCache.
-func NewAggregateCache() *AggregateCache {
+func NewAggregateCache(scheme *runtime.Scheme) *AggregateCache {
 	return &AggregateCache{
+		scheme:    scheme,
 		caches:    make(map[string]WildcardCache),
-		informers: make(map[reflect.Type]*aggregateSharedIndexInformer),
+		informers: make(map[schema.GroupVersionKind]*aggregateSharedIndexInformer),
 	}
 }
 
@@ -82,19 +86,22 @@ func (a *AggregateCache) RemoveCache(id string) {
 // GetAggregateInformer returns an AggregateSharedIndexInformer for the given object type.
 // The returned informer aggregates events from all current and future shards.
 // Calling this method multiple times with the same object type returns the same informer instance.
-func (a *AggregateCache) GetAggregateInformer(obj runtime.Object) AggregateSharedIndexInformer {
-	objType := reflect.TypeOf(obj)
+func (a *AggregateCache) GetAggregateInformer(obj runtime.Object) (AggregateSharedIndexInformer, error) {
+	gvk, err := apiutil.GVKForObject(obj, a.scheme)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get GVK for object: %w", err)
+	}
 
 	a.informersLock.Lock()
 	defer a.informersLock.Unlock()
 
-	if inf, ok := a.informers[objType]; ok {
-		return inf
+	if inf, ok := a.informers[gvk]; ok {
+		return inf, nil
 	}
 
 	inf := newAggregateSharedIndexInformer(a, obj)
-	a.informers[objType] = inf
-	return inf
+	a.informers[gvk] = inf
+	return inf, nil
 }
 
 // List aggregates results from all registered caches.

--- a/pkg/cache/aggregate.go
+++ b/pkg/cache/aggregate.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	toolscache "k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -95,4 +96,21 @@ func (a *AggregateCache) List(ctx context.Context, list client.ObjectList, opts 
 	}
 
 	return kerrors.NewAggregate(errs)
+}
+
+// GetSharedInformers returns SharedIndexInformers for all registered shard caches.
+// Users can use these informers to register event handlers across all shards.
+func (a *AggregateCache) GetSharedInformers(obj runtime.Object) ([]toolscache.SharedIndexInformer, error) {
+	a.lock.RLock()
+	defer a.lock.RUnlock()
+
+	result := make([]toolscache.SharedIndexInformer, 0, len(a.caches))
+	for id, c := range a.caches {
+		inf, _, _, err := c.GetSharedInformer(obj)
+		if err != nil {
+			return nil, fmt.Errorf("shard %q: %w", id, err)
+		}
+		result = append(result, inf)
+	}
+	return result, nil
 }

--- a/pkg/cache/aggregate_informer.go
+++ b/pkg/cache/aggregate_informer.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	toolscache "k8s.io/client-go/tools/cache"
+)
+
+// AggregateSharedIndexInformer provides SharedIndexInformer-like functionality
+// that aggregates across all shards and handles dynamic cache changes.
+type AggregateSharedIndexInformer interface {
+	// AddEventHandler registers a handler that receives events from all
+	// current and future shards.
+	AddEventHandler(handler toolscache.ResourceEventHandler) (toolscache.ResourceEventHandlerRegistration, error)
+
+	// AddEventHandlerWithResyncPeriod registers a handler with a resync period.
+	AddEventHandlerWithResyncPeriod(handler toolscache.ResourceEventHandler, resyncPeriod time.Duration) (toolscache.ResourceEventHandlerRegistration, error)
+
+	// HasSynced returns true when all current shard informers have synced.
+	HasSynced() bool
+}
+
+// handlerEntry tracks a registered handler and its per-cache registrations.
+type handlerEntry struct {
+	handler       toolscache.ResourceEventHandler
+	resyncPeriod  time.Duration
+	registrations map[string]toolscache.ResourceEventHandlerRegistration
+}
+
+// aggregateSharedIndexInformer implements AggregateSharedIndexInformer.
+type aggregateSharedIndexInformer struct {
+	cache *AggregateCache
+	obj   runtime.Object
+
+	lock     sync.RWMutex
+	handlers []*handlerEntry
+}
+
+var _ AggregateSharedIndexInformer = &aggregateSharedIndexInformer{}
+
+// newAggregateSharedIndexInformer creates a new aggregate informer for the given object type.
+func newAggregateSharedIndexInformer(cache *AggregateCache, obj runtime.Object) *aggregateSharedIndexInformer {
+	return &aggregateSharedIndexInformer{
+		cache:    cache,
+		obj:      obj,
+		handlers: make([]*handlerEntry, 0),
+	}
+}
+
+// AddEventHandler registers a handler that receives events from all current and future shards.
+func (a *aggregateSharedIndexInformer) AddEventHandler(handler toolscache.ResourceEventHandler) (toolscache.ResourceEventHandlerRegistration, error) {
+	return a.AddEventHandlerWithResyncPeriod(handler, 0)
+}
+
+// AddEventHandlerWithResyncPeriod registers a handler with a resync period.
+func (a *aggregateSharedIndexInformer) AddEventHandlerWithResyncPeriod(handler toolscache.ResourceEventHandler, resyncPeriod time.Duration) (toolscache.ResourceEventHandlerRegistration, error) {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	handlerEntry := &handlerEntry{
+		handler:       handler,
+		resyncPeriod:  resyncPeriod,
+		registrations: make(map[string]toolscache.ResourceEventHandlerRegistration),
+	}
+
+	// Register with all current caches
+	a.cache.lock.RLock()
+	for cacheID, c := range a.cache.caches {
+		inf, _, _, err := c.GetSharedInformer(a.obj)
+		if err != nil {
+			a.cache.lock.RUnlock()
+			a.cleanupRegistrations(handlerEntry)
+			return nil, fmt.Errorf("cache %q: failed to get informer: %w", cacheID, err)
+		}
+		reg, err := inf.AddEventHandlerWithResyncPeriod(handler, resyncPeriod)
+		if err != nil {
+			a.cache.lock.RUnlock()
+			a.cleanupRegistrations(handlerEntry)
+			return nil, fmt.Errorf("cache %q: failed to add handler: %w", cacheID, err)
+		}
+		handlerEntry.registrations[cacheID] = reg
+	}
+	a.cache.lock.RUnlock()
+
+	// Track handler so we can register it with future caches
+	a.handlers = append(a.handlers, handlerEntry)
+
+	return &aggregateRegistration{
+		informer:     a,
+		handlerEntry: handlerEntry,
+	}, nil
+}
+
+// cleanupRegistrations removes all registrations for an entry.
+func (a *aggregateSharedIndexInformer) cleanupRegistrations(entry *handlerEntry) {
+	a.cache.lock.RLock()
+	defer a.cache.lock.RUnlock()
+
+	for id, reg := range entry.registrations {
+		if c, ok := a.cache.caches[id]; ok {
+			if inf, _, _, err := c.GetSharedInformer(a.obj); err == nil {
+				_ = inf.RemoveEventHandler(reg)
+			}
+		}
+	}
+}
+
+// onCacheAdded is called when a new cache is added - registers all existing handlers.
+func (a *aggregateSharedIndexInformer) onCacheAdded(cacheID string, c WildcardCache) {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	inf, _, _, err := c.GetSharedInformer(a.obj)
+	if err != nil {
+		// Cache may not support this object type - skip silently
+		return
+	}
+
+	for _, entry := range a.handlers {
+		reg, err := inf.AddEventHandlerWithResyncPeriod(entry.handler, entry.resyncPeriod)
+		if err != nil {
+			continue
+		}
+		entry.registrations[cacheID] = reg
+	}
+}
+
+// onCacheRemoved is called when a cache is removed - cleans up registrations.
+func (a *aggregateSharedIndexInformer) onCacheRemoved(cacheID string) {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	for _, entry := range a.handlers {
+		delete(entry.registrations, cacheID)
+	}
+}
+
+// HasSynced returns true when all current shard informers have synced.
+func (a *aggregateSharedIndexInformer) HasSynced() bool {
+	a.cache.lock.RLock()
+	defer a.cache.lock.RUnlock()
+
+	// If no shards, consider synced
+	if len(a.cache.caches) == 0 {
+		return true
+	}
+
+	for _, c := range a.cache.caches {
+		inf, _, _, err := c.GetSharedInformer(a.obj)
+		if err != nil {
+			// If we can't get the informer, it's not synced
+			return false
+		}
+		if !inf.HasSynced() {
+			return false
+		}
+	}
+	return true
+}
+
+// aggregateRegistration implements toolscache.ResourceEventHandlerRegistration
+// for aggregate informers.
+type aggregateRegistration struct {
+	informer     *aggregateSharedIndexInformer
+	handlerEntry *handlerEntry
+}
+
+var _ toolscache.ResourceEventHandlerRegistration = &aggregateRegistration{}
+
+// HasSynced returns true when all shard registrations have synced.
+func (r *aggregateRegistration) HasSynced() bool {
+	r.informer.lock.RLock()
+	defer r.informer.lock.RUnlock()
+
+	for _, reg := range r.handlerEntry.registrations {
+		if !reg.HasSynced() {
+			return false
+		}
+	}
+	return true
+}
+
+// HasSyncedChecker returns nil - use HasSynced() for sync checking.
+func (r *aggregateRegistration) HasSyncedChecker() toolscache.DoneChecker {
+	return nil
+}

--- a/pkg/cache/aggregate_informer.go
+++ b/pkg/cache/aggregate_informer.go
@@ -73,6 +73,9 @@ func (a *aggregateSharedIndexInformer) AddEventHandler(handler toolscache.Resour
 
 // AddEventHandlerWithResyncPeriod registers a handler with a resync period.
 func (a *aggregateSharedIndexInformer) AddEventHandlerWithResyncPeriod(handler toolscache.ResourceEventHandler, resyncPeriod time.Duration) (toolscache.ResourceEventHandlerRegistration, error) {
+	a.cache.lock.RLock()
+	defer a.cache.lock.RUnlock()
+
 	a.lock.Lock()
 	defer a.lock.Unlock()
 
@@ -83,23 +86,19 @@ func (a *aggregateSharedIndexInformer) AddEventHandlerWithResyncPeriod(handler t
 	}
 
 	// Register with all current caches
-	a.cache.lock.RLock()
 	for cacheID, c := range a.cache.caches {
 		inf, _, _, err := c.GetSharedInformer(a.obj)
 		if err != nil {
-			a.cache.lock.RUnlock()
 			a.cleanupRegistrations(handlerEntry)
 			return nil, fmt.Errorf("cache %q: failed to get informer: %w", cacheID, err)
 		}
 		reg, err := inf.AddEventHandlerWithResyncPeriod(handler, resyncPeriod)
 		if err != nil {
-			a.cache.lock.RUnlock()
 			a.cleanupRegistrations(handlerEntry)
 			return nil, fmt.Errorf("cache %q: failed to add handler: %w", cacheID, err)
 		}
 		handlerEntry.registrations[cacheID] = reg
 	}
-	a.cache.lock.RUnlock()
 
 	// Track handler so we can register it with future caches
 	a.handlers = append(a.handlers, handlerEntry)
@@ -112,9 +111,6 @@ func (a *aggregateSharedIndexInformer) AddEventHandlerWithResyncPeriod(handler t
 
 // cleanupRegistrations removes all registrations for an entry.
 func (a *aggregateSharedIndexInformer) cleanupRegistrations(entry *handlerEntry) {
-	a.cache.lock.RLock()
-	defer a.cache.lock.RUnlock()
-
 	for id, reg := range entry.registrations {
 		if c, ok := a.cache.caches[id]; ok {
 			if inf, _, _, err := c.GetSharedInformer(a.obj); err == nil {

--- a/pkg/cache/aggregate_informer_test.go
+++ b/pkg/cache/aggregate_informer_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2025 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+func TestGetAggregateInformer(t *testing.T) {
+	tests := []struct {
+		name     string
+		obj1     runtime.Object
+		obj2     runtime.Object
+		wantSame bool
+		wantErr  bool
+	}{
+		{
+			name:     "same typed object returns same instance",
+			obj1:     &corev1.Pod{},
+			obj2:     &corev1.Pod{},
+			wantSame: true,
+		},
+		{
+			name:     "different typed objects return different instances",
+			obj1:     &corev1.Pod{},
+			obj2:     &corev1.ConfigMap{},
+			wantSame: false,
+		},
+		{
+			name: "unstructured with different GVKs return different instances",
+			obj1: func() runtime.Object {
+				u := &unstructured.Unstructured{}
+				u.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"})
+				return u
+			}(),
+			obj2: func() runtime.Object {
+				u := &unstructured.Unstructured{}
+				u.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"})
+				return u
+			}(),
+			wantSame: false,
+		},
+		{
+			name: "unstructured with same GVK returns same instance",
+			obj1: func() runtime.Object {
+				u := &unstructured.Unstructured{}
+				u.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"})
+				return u
+			}(),
+			obj2: func() runtime.Object {
+				u := &unstructured.Unstructured{}
+				u.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"})
+				return u
+			}(),
+			wantSame: true,
+		},
+		{
+			name:    "unstructured without GVK returns error",
+			obj1:    &unstructured.Unstructured{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ac := NewAggregateCache(scheme.Scheme)
+
+			inf1, err := ac.GetAggregateInformer(tt.obj1)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			inf2, err := ac.GetAggregateInformer(tt.obj2)
+			require.NoError(t, err)
+
+			if tt.wantSame {
+				require.Same(t, inf1, inf2, "expected same informer instance")
+			} else {
+				require.NotSame(t, inf1, inf2, "expected different informer instances")
+			}
+		})
+	}
+}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -207,9 +207,12 @@ func (p *Provider) Lister() mcpcache.Lister {
 	return p.aggregateCache
 }
 
-// GetSharedInformers returns SharedIndexInformers for all registered shard caches.
-func (p *Provider) GetSharedInformers(obj runtime.Object) ([]toolscache.SharedIndexInformer, error) {
-	return p.aggregateCache.GetSharedInformers(obj)
+// GetAggregateInformer returns an AggregateSharedIndexInformer for the given object type.
+// The returned informer aggregates events from all current and future shards.
+// Event handlers registered with this informer will receive events from all shards,
+// and will automatically be registered with new shards as they are added.
+func (p *Provider) GetAggregateInformer(obj runtime.Object) mcpcache.AggregateSharedIndexInformer {
+	return p.aggregateCache.GetAggregateInformer(obj)
 }
 
 // IndexField adds an indexer to the clusters managed by this provider.

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -207,6 +207,11 @@ func (p *Provider) Lister() mcpcache.Lister {
 	return p.aggregateCache
 }
 
+// GetSharedInformers returns SharedIndexInformers for all registered shard caches.
+func (p *Provider) GetSharedInformers(obj runtime.Object) ([]toolscache.SharedIndexInformer, error) {
+	return p.aggregateCache.GetSharedInformers(obj)
+}
+
 // IndexField adds an indexer to the clusters managed by this provider.
 func (p *Provider) IndexField(ctx context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error {
 	return p.Clusters.IndexField(ctx, obj, field, extractValue)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -192,7 +192,7 @@ func NewProvider(cfg *rest.Config, endpointSliceName string, opts Options) (*Pro
 			stopRecorderProvider: p.recorderManager.StopProvider,
 		})
 	}
-	p.aggregateCache = mcpcache.NewAggregateCache()
+	p.aggregateCache = mcpcache.NewAggregateCache(p.opts.Scheme)
 
 	return p, nil
 }
@@ -211,7 +211,7 @@ func (p *Provider) Lister() mcpcache.Lister {
 // The returned informer aggregates events from all current and future shards.
 // Event handlers registered with this informer will receive events from all shards,
 // and will automatically be registered with new shards as they are added.
-func (p *Provider) GetAggregateInformer(obj runtime.Object) mcpcache.AggregateSharedIndexInformer {
+func (p *Provider) GetAggregateInformer(obj runtime.Object) (mcpcache.AggregateSharedIndexInformer, error) {
 	return p.aggregateCache.GetAggregateInformer(obj)
 }
 

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -56,7 +56,7 @@ func testProvider(t *testing.T, extractURLs func(client.Object) ([]string, error
 		config:           &rest.Config{Host: "https://kcp.example.com"},
 		Clusters:         clusters.New[cluster.Cluster](),
 		watchedEndpoints: map[string]*watchedEndpoint{},
-		aggregateCache:   mcpcache.NewAggregateCache(),
+		aggregateCache:   mcpcache.NewAggregateCache(scheme.Scheme),
 	}
 
 	p.watchEndpointFunc = func(ctx context.Context, cfg *rest.Config, aware multicluster.Aware) (*watchedEndpoint, error) {

--- a/test/e2e/aggregate_cache_test.go
+++ b/test/e2e/aggregate_cache_test.go
@@ -278,7 +278,7 @@ var _ = Describe("AggregateCache", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("creating an AggregateCache backed by one wildcard cache per APIExport endpoint")
-			aggregateCache = mcpcache.NewAggregateCache()
+			aggregateCache = mcpcache.NewAggregateCache(scheme.Scheme)
 			widgetForIndex := &unstructured.Unstructured{}
 			widgetForIndex.SetGroupVersionKind(runtimeschema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Widget"})
 

--- a/test/e2e/aggregate_cache_test.go
+++ b/test/e2e/aggregate_cache_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	toolscache "k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -421,6 +422,57 @@ var _ = Describe("AggregateCache", Ordered, func() {
 				}
 				return l.Items[0].GetName() == "blue-widget", fmt.Sprintf("expected blue-widget, got %s", l.Items[0].GetName())
 			}, wait.ForeverTestTimeout, time.Millisecond*100, "failed to list blue widgets via aggregate cache with field index")
+		})
+
+		It("can receive events via aggregate informer from all shards", func() {
+			By("getting an aggregate informer for widgets")
+			widgetGVK := runtimeschema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Widget"}
+			widgetForInformer := &unstructured.Unstructured{}
+			widgetForInformer.SetGroupVersionKind(widgetGVK)
+
+			aggInf, err := aggregateCache.GetAggregateInformer(widgetForInformer)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("registering an event handler")
+			var addedWidgets sync.Map // map[string]bool for thread-safe access
+			_, err = aggInf.AddEventHandler(&toolscache.ResourceEventHandlerFuncs{
+				AddFunc: func(obj any) {
+					u := obj.(*unstructured.Unstructured)
+					addedWidgets.Store(u.GetName(), true)
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("waiting for the handler to receive existing widgets from all shards")
+			envtest.Eventually(GinkgoT(), func() (bool, string) {
+				_, hasRed := addedWidgets.Load("red-widget")
+				_, hasBlue := addedWidgets.Load("blue-widget")
+				if hasRed && hasBlue {
+					return true, ""
+				}
+				var names []string
+				addedWidgets.Range(func(key, _ any) bool {
+					names = append(names, key.(string))
+					return true
+				})
+				return false, fmt.Sprintf("expected red-widget and blue-widget, got %v", names)
+			}, wait.ForeverTestTimeout, time.Millisecond*100, "failed to receive add events for existing widgets")
+
+			By("creating a new widget in consumer1 and verifying the handler receives it")
+			greenWidget := &unstructured.Unstructured{}
+			greenWidget.SetGroupVersionKind(widgetGVK)
+			greenWidget.SetName("green-widget")
+			greenWidget.SetLabels(map[string]string{"color": "green"})
+			err = cli.Cluster(consumer1Path).Create(ctx, greenWidget)
+			Expect(err).NotTo(HaveOccurred())
+
+			envtest.Eventually(GinkgoT(), func() (bool, string) {
+				_, hasGreen := addedWidgets.Load("green-widget")
+				if hasGreen {
+					return true, ""
+				}
+				return false, "green-widget not yet received"
+			}, wait.ForeverTestTimeout, time.Millisecond*100, "failed to receive add event for new widget")
 		})
 
 		AfterAll(func() {


### PR DESCRIPTION
On-behalf-of: @SAP aleh.yarshou@sap.com

<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary
The goal of this PR is to add a sharedInformer exposure from the provider to the user. It allows users to set their handlers on the resources against aggregated cache by setting handlers on each wildcard cache informer. When new shards appears, it adds handlers to them, when shards removed, their caches are removed with informers what removes handlers automaticly.


## What Type of PR Is This?
/kind feature 
<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Added pkg/cache.AggregateSharedIndexInformer and pkg/provider.Provider.GetAggregateInformer, a shared index informer over all shards watched by the provider
```
